### PR TITLE
Use current stable version of JCPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>com.fluxchess</groupId>
       <artifactId>jcpi</artifactId>
-      <version>1.2.0-alpha.113</version>
+      <version>1.1.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Hey Bill

Nice to see you coding again on your chess engine! I have noticed that you switched to the latest version of JCPI. I hope the transition and refactoring wasn't that painful. :)

To have you not going through it again, I've created this pull request to change the version to the stable branch. The branch 1.2.x might probably change a lot, that's why it's currently tagged as alpha. Please consider merging this in, so that you're building against the stable version.

Cheers,
Poky
