### PR TITLE
Improve MoveGeneratorTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>com.fluxchess</groupId>
       <artifactId>jcpi</artifactId>
-      <version>1.1.3</version>
+      <version>1.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/src/main/java/com/es/Board.java
+++ b/src/main/java/com/es/Board.java
@@ -564,6 +564,45 @@ public final class Board implements Cloneable {
         return sb.toString();
     }
 
+    public GenericBoard toGenericBoard() {
+        GenericBoard genericBoard = new GenericBoard();
+
+        for (GenericPosition genericPosition : GenericPosition.values()) {
+            int file = genericPosition.file.ordinal();
+            int rank = genericPosition.rank.ordinal();
+            int position = rank * 16 + file;
+
+            Piece piece = board[position];
+            if(piece != null) {
+                GenericPiece genericPiece = GenericPiece.valueOf(piece.toString().charAt(0));
+                genericBoard.setPiece(genericPiece, genericPosition);
+            }
+        }
+
+        genericBoard.setActiveColor(GenericColor.valueOf(getActiveColor().toFENString().charAt(0)));
+
+        if(this.whiteKingCastle) {
+            genericBoard.setCastling(GenericColor.WHITE, GenericCastling.KINGSIDE, GenericFile.Fh);
+        };
+        if(this.whiteQueenCastle) {
+            genericBoard.setCastling(GenericColor.WHITE, GenericCastling.QUEENSIDE, GenericFile.Fa);
+        };
+        if(this.blackKingCastle) {
+            genericBoard.setCastling(GenericColor.BLACK, GenericCastling.KINGSIDE, GenericFile.Fh);
+        };
+        if(this.blackQueenCastle) {
+            genericBoard.setCastling(GenericColor.BLACK, GenericCastling.QUEENSIDE, GenericFile.Fa);
+        };
+
+        if(this.enPassant != MAX_SQUARE) {
+            genericBoard.setEnPassant(GenericPosition.valueOf(Board.squareToString(this.enPassant)));
+        }
+
+        genericBoard.setFullMoveNumber(getMoves());
+
+        return genericBoard;
+    }
+    
     /**
      * Given the current board's state, generate all of the possible moves.
      * @return an array containing all possible moves for the board.

--- a/src/main/java/com/es/engines/UciEngine.java
+++ b/src/main/java/com/es/engines/UciEngine.java
@@ -119,7 +119,7 @@ public class UciEngine extends AbstractEngine {
         LOG.info("Engine Analyze: color={}", command.board.getActiveColor().toChar());
 
         if(LOG.isInfoEnabled()) {
-            LOG.info("MOVE LIST SIZE: {}", command.moveList.size());
+            LOG.info("MOVE LIST SIZE: {}", command.moves.size());
             LOG.info("BOARD SENT:");
             LOG.info(command.board.toString());
         }
@@ -131,7 +131,7 @@ public class UciEngine extends AbstractEngine {
 
         // Make all moves here! UCI is not stateful! So we have to setup the board as the protocol says.
         // Don't just take the last move!
-        List<GenericMove> moveList = command.moveList;
+        List<GenericMove> moveList = command.moves;
         for (GenericMove move : moveList) {
             try {
                 // TODO: Add in piece promotion here

--- a/src/test/java/com/es/BoardTest.java
+++ b/src/test/java/com/es/BoardTest.java
@@ -36,6 +36,14 @@ public class BoardTest {
     }
 
     @Test
+    public void testToGenericBoard() {
+        GenericBoard genericBoard = new GenericBoard(GenericBoard.STANDARDSETUP);
+        Board testBoard = new Board(genericBoard);
+
+        assertEquals(genericBoard, testBoard.toGenericBoard());
+    }
+
+    @Test
     public void testMap() {
         Map<Board, Integer> map = new HashMap<Board, Integer>();
 


### PR DESCRIPTION
Hey Bill!

I tried to figure out how to improve your move generator test by using the new move generator tool from JCPI. This pull request adds a new toGenericBoard() method to the Board class which will be used by the move generator test. I've added a new findMissingMoves() method to the test which will print out all missing and illegal moves for a specific board. You can test it yourself by e.g. not generating all promotion moves. Seems like your move generator is pretty solid already... Oh well!

Cheers,
Poky
